### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+---
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  container:
+    name: Build container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Login to dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_READONLY_TOKEN }}
+      - name: Build container
+        run: make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# Tested on:
+# - Fedora 42 (linux/amd64)
+
+REGISTRY := dockerhub.io
+USER := minikubebot
+IMAGE := xcgo
+TAG := devel
+TOOL := docker
+
+image_url = $(REGISTRY)/$(USER)/$(IMAGE):$(TAG)
+
+.PHONY: build
+
+build:
+	$(TOOL) build --tag $(image_url) .


### PR DESCRIPTION
- Add Makefile to make it easy to build a development image
- Add build workflow building the image for every PR

We need to add a release workflow to push to image to the register, but first lets have a working build.